### PR TITLE
[UPDATE] modify create and update api fro persistent-subscriptions

### DIFF
--- a/Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.Settings.swift
+++ b/Sources/KurrentDB/Core/PersistenSubscription/PersistentSubscription.Settings.swift
@@ -65,5 +65,8 @@ extension PersistentSubscription {
             self.checkpointAfter = checkpointAfter
             self.consumerStrategy = consumerStrategy
         }
+        
+        
+        
     }
 }

--- a/Sources/KurrentDB/PersistentSubscriptions/Additions/EventStore_Client_PersistentSubscriptions+Additions.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Additions/EventStore_Client_PersistentSubscriptions+Additions.swift
@@ -40,7 +40,7 @@ extension EventStore_Client_PersistentSubscriptions_CreateReq.Settings {
 }
 
 extension EventStore_Client_PersistentSubscriptions_UpdateReq.Settings {
-    package static func make(settings: PersistentSubscription.Settings) -> Self {
+    package static func from(settings: PersistentSubscription.Settings) -> Self {
         .with {
             $0.resolveLinks = settings.resolveLink
             $0.extraStatistics = settings.extraStatistics

--- a/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptions.swift
@@ -109,8 +109,8 @@ extension PersistentSubscriptions where Target == PersistentSubscription.All {
     /// - Parameters:
     ///   - options: Configuration options for creating the subscription, defaulting to an empty configuration.
     /// - Throws: An error if the creation fails.
-    public func create(options: CreateToAll.Options = .init()) async throws(KurrentError) {
-        let usecase: CreateToAll = .init(group: group, options: options)
+    public func create(startFrom cursor: PositionCursor = .end, options: CreateToAll.Options = .init()) async throws(KurrentError) {
+        let usecase = CreateToAll(group: group, cursor: cursor, options: options)
         _ = try await usecase.perform(settings: clientSettings, callOptions: callOptions)
     }
     
@@ -119,8 +119,8 @@ extension PersistentSubscriptions where Target == PersistentSubscription.All {
     /// - Parameters:
     ///   - options: Configuration options for updating the subscription, defaulting to an empty configuration.
     /// - Throws: An error if the update fails.
-    public func update(options: UpdateToAll.Options = .init()) async throws(KurrentError) {
-        let usecase = UpdateToAll(group: group, options: options)
+    public func update(startFrom cursor: PositionCursor = .end, options: UpdateToAll.Options = .init()) async throws(KurrentError) {
+        let usecase = UpdateToAll(group: group, cursor: cursor, options: options)
         _ = try await usecase.perform(settings: clientSettings, callOptions: callOptions)
     }
     
@@ -185,8 +185,8 @@ extension PersistentSubscriptions where Target == PersistentSubscription.Specifi
     /// - Parameters:
     ///   - options: Configuration options for creating the subscription, defaulting to an empty configuration.
     /// - Throws: An error if the creation fails.
-    public func create(options: CreateToStream.Options = .init()) async throws(KurrentError) {
-        let usecase: CreateToStream = .init(streamIdentifier: streamIdentifier, group: group, options: options)
+    public func create(startFrom cursor: RevisionCursor = .end, options: CreateToStream.Options = .init()) async throws(KurrentError) {
+        let usecase = CreateToStream(streamIdentifier: streamIdentifier, group: group, cursor: cursor, options: options)
         _ = try await usecase.perform(settings: clientSettings, callOptions: callOptions)
     }
 
@@ -195,8 +195,8 @@ extension PersistentSubscriptions where Target == PersistentSubscription.Specifi
     /// - Parameters:
     ///   - options: Configuration options for updating the subscription, defaulting to an empty configuration.
     /// - Throws: An error if the update fails.
-    public func update(settings: PersistentSubscription.Settings, from cursor: RevisionCursor = .end) async throws(KurrentError) {
-        let usecase = UpdateToStream(streamIdentifier: streamIdentifier, group: group, options: .init(settings: settings).startFrom(cursor: cursor))
+    public func update(startFrom cursor: RevisionCursor = .end, options: UpdateToStream.Options = .init()) async throws(KurrentError) {
+        let usecase = UpdateToStream(streamIdentifier: streamIdentifier, group: group, cursor: cursor, options: options)
         _ = try await usecase.perform(settings: clientSettings, callOptions: callOptions)
     }
 

--- a/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptionsCommonOptions.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/PersistentSubscriptionsCommonOptions.swift
@@ -14,6 +14,67 @@ protocol PersistentSubscriptionsCommonOptions: EventStoreOptions {
 
 extension PersistentSubscriptionsCommonOptions {
     @discardableResult
+    public func resolveLink() -> Self {
+        withCopy { $0.settings.resolveLink = true }
+    }
+
+    @discardableResult
+    public func extraStatistics() -> Self {
+        withCopy { $0.settings.extraStatistics = true }
+    }
+
+    @discardableResult
+    public func messageTimeout(_ value: TimeSpan) -> Self {
+        withCopy { $0.settings.messageTimeout = value }
+    }
+
+    @discardableResult
+    public func maxRetryCount(_ value: Int32) -> Self {
+        withCopy { $0.settings.maxRetryCount = value }
+    }
+
+    @discardableResult
+    public func checkpoint(count value: ClosedRange<Int32>) -> Self {
+        withCopy { $0.settings.checkpointCount = value }
+    }
+    
+    @discardableResult
+    public func checkpoint(after value: TimeSpan) -> Self {
+        withCopy { $0.settings.checkpointAfter = value }
+    }
+
+    @discardableResult
+    public func maxSubscriberCount(_ value: Int32) -> Self {
+        withCopy { $0.settings.maxSubscriberCount = value }
+    }
+
+    @discardableResult
+    public func liveBufferSize(_ value: Int32) -> Self {
+        withCopy { $0.settings.liveBufferSize = value }
+    }
+
+    @discardableResult
+    public func readBatchSize(_ value: Int32) -> Self {
+        withCopy { $0.settings.readBatchSize = value }
+    }
+
+    @discardableResult
+    public func historyBufferSize(_ value: Int32) -> Self {
+        withCopy { $0.settings.historyBufferSize = value }
+    }
+
+    
+
+    @discardableResult
+    public func consumerStrategy(_ value: PersistentSubscription.SystemConsumerStrategy) -> Self {
+        withCopy { $0.settings.consumerStrategy = value }
+    }
+}
+
+// MARK: - Deprecated
+extension PersistentSubscriptionsCommonOptions {
+    @discardableResult
+    @available(*, deprecated)
     public mutating func set(resolveLinks: Bool) -> Self {
         withCopy { copied in
             copied.settings.resolveLink = resolveLinks
@@ -21,6 +82,7 @@ extension PersistentSubscriptionsCommonOptions {
     }
 
     @discardableResult
+    @available(*, deprecated)
     public mutating func set(extraStatistics: Bool) -> Self {
         withCopy { copied in
             copied.settings.extraStatistics = extraStatistics
@@ -28,6 +90,7 @@ extension PersistentSubscriptionsCommonOptions {
     }
 
     @discardableResult
+    @available(*, deprecated)
     public mutating func set(maxRetryCount: Int32) -> Self {
         withCopy { copied in
             copied.settings.maxRetryCount = maxRetryCount
@@ -35,6 +98,7 @@ extension PersistentSubscriptionsCommonOptions {
     }
 
     @discardableResult
+    @available(*, deprecated)
     public mutating func set(minCheckpointCount: Int32) -> Self {
         withCopy { copied in
             copied.settings.checkpointCount = minCheckpointCount ... settings.checkpointCount.upperBound
@@ -42,6 +106,7 @@ extension PersistentSubscriptionsCommonOptions {
     }
 
     @discardableResult
+    @available(*, deprecated)
     public mutating func set(maxCheckpointCount: Int32) -> Self {
         withCopy { copied in
             copied.settings.checkpointCount = settings.checkpointCount.lowerBound ... maxCheckpointCount
@@ -49,6 +114,7 @@ extension PersistentSubscriptionsCommonOptions {
     }
 
     @discardableResult
+    @available(*, deprecated)
     public mutating func set(maxSubscriberCount: Int32) -> Self {
         withCopy { copied in
             copied.settings.maxSubscriberCount = maxSubscriberCount
@@ -56,6 +122,7 @@ extension PersistentSubscriptionsCommonOptions {
     }
 
     @discardableResult
+    @available(*, deprecated)
     public mutating func set(liveBufferSize: Int32) -> Self {
         withCopy { copied in
             copied.settings.liveBufferSize = liveBufferSize
@@ -63,6 +130,7 @@ extension PersistentSubscriptionsCommonOptions {
     }
 
     @discardableResult
+    @available(*, deprecated)
     public mutating func set(readBatchSize: Int32) -> Self {
         withCopy { copied in
             copied.settings.readBatchSize = readBatchSize
@@ -70,6 +138,7 @@ extension PersistentSubscriptionsCommonOptions {
     }
 
     @discardableResult
+    @available(*, deprecated)
     public mutating func set(historyBufferSize: Int32) -> Self {
         withCopy { copied in
             copied.settings.historyBufferSize = historyBufferSize
@@ -77,6 +146,7 @@ extension PersistentSubscriptionsCommonOptions {
     }
 
     @discardableResult
+    @available(*, deprecated)
     public mutating func set(messageTimeout timeout: TimeSpan) -> Self {
         withCopy { copied in
             copied.settings.messageTimeout = timeout
@@ -84,6 +154,7 @@ extension PersistentSubscriptionsCommonOptions {
     }
 
     @discardableResult
+    @available(*, deprecated)
     public mutating func setCheckpoint(after span: TimeSpan) -> Self {
         withCopy { copied in
             copied.settings.checkpointAfter = span

--- a/Sources/KurrentDB/PersistentSubscriptions/Usecase/PersistentSubscriptions.UpdateToStream.swift
+++ b/Sources/KurrentDB/PersistentSubscriptions/Usecase/PersistentSubscriptions.UpdateToStream.swift
@@ -17,19 +17,31 @@ extension PersistentSubscriptions {
 
         var streamIdentifier: StreamIdentifier
         var group: String
+        var cursor: RevisionCursor
         var options: Options
 
-        init(streamIdentifier: StreamIdentifier, group: String, options: Options) {
+        init(streamIdentifier: StreamIdentifier, group: String, cursor: RevisionCursor, options: Options) {
             self.streamIdentifier = streamIdentifier
             self.group = group
+            self.cursor = cursor
             self.options = options
         }
 
         package func requestMessage() throws -> UnderlyingRequest {
             try .with {
                 $0.options = options.build()
-                $0.options.groupName = group
                 $0.options.stream.streamIdentifier = try streamIdentifier.build()
+                $0.options.groupName = group
+                
+                
+                switch cursor {
+                case .start:
+                    $0.options.stream.start = .init()
+                case .end:
+                    $0.options.stream.end = .init()
+                case let .revision(revision):
+                    $0.options.stream.revision = revision
+                }
             }
         }
 
@@ -42,36 +54,18 @@ extension PersistentSubscriptions {
 }
 
 extension PersistentSubscriptions.UpdateToStream {
-    public struct Options: EventStoreOptions {
+    public struct Options: PersistentSubscriptionsCommonOptions {
         package typealias UnderlyingMessage = UnderlyingRequest.Options
 
-        public private(set) var settings: PersistentSubscription.Settings
-        public private(set) var revisionCursor: RevisionCursor
+        public internal(set) var settings: PersistentSubscription.Settings
 
-        public init(settings: PersistentSubscription.Settings = .init(), revisionCursor: RevisionCursor = .end) {
-            self.settings = settings
-            self.revisionCursor = revisionCursor
-        }
-
-        @discardableResult
-        public func startFrom(cursor: RevisionCursor) -> Self {
-            withCopy { options in
-                options.revisionCursor = cursor
-            }
+        public init() {
+            self.settings = .init()
         }
 
         package func build() -> UnderlyingMessage {
             .with {
-                $0.settings = .make(settings: settings)
-
-                switch revisionCursor {
-                case .start:
-                    $0.stream.start = .init()
-                case .end:
-                    $0.stream.end = .init()
-                case let .revision(revision):
-                    $0.stream.revision = revision
-                }
+                $0.settings = .from(settings: settings)
             }
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support to specify a starting cursor when creating and updating subscriptions, giving users more control over the subscription start position.
  - Introduced additional configuration options for managing subscription settings such as timeouts, retry counts, and consumer strategies.

- **Refactor**
  - Updated public API method signatures and names for a clearer and more standardized subscription interface.
  - Streamlined options handling by removing outdated methods and integrating the new cursor-based approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->